### PR TITLE
Add 'rb' to open() to support python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setup(
   license="Apache License 2.0",   
   keywords="sass scss libsass",  
   description='Python bindings for libsass',
-  long_description=open(os.path.join(here, 'README.rst')).read().decode('utf-8')    
+  long_description=open(os.path.join(here, 'README.rst'), 'rb').read().decode('utf-8')    
 )


### PR DESCRIPTION
In python 3, we should explicitly say that file is opening in binary mode (so read() returns bytes and we can decode it using utf-8)
