### PR TITLE
Updated code to use b-prefixed strings for Python 2/3 compatibility

### DIFF
--- a/sass.pyx
+++ b/sass.pyx
@@ -56,7 +56,7 @@ class CompileError(Exception): pass
 def compile_string(bytes s, include_paths=None, int output_style=SASS_STYLE_NESTED):
     """Compiles SASS string to CSS"""
 
-    include_paths = include_paths or ''
+    include_paths = include_paths or b''
     cdef sass_context* ctx = sass_new_context()
     try:
         ctx.source_string = s
@@ -73,7 +73,7 @@ def compile_string(bytes s, include_paths=None, int output_style=SASS_STYLE_NEST
 def compile_file(bytes path, include_paths=None, int output_style=SASS_STYLE_NESTED):
     """Compiles SASS file to CSS string"""
 
-    include_paths = include_paths or ''
+    include_paths = include_paths or b''
     cdef sass_file_context* ctx = sass_new_file_context()
     try:
         ctx.input_path = path
@@ -84,4 +84,4 @@ def compile_file(bytes path, include_paths=None, int output_style=SASS_STYLE_NES
             raise CompileError(ctx.error_message or 'Unknown compilation error')
         return ctx.output_string
     finally:
-        sass_free_file_context(ctx)        
+        sass_free_file_context(ctx)

--- a/test.py
+++ b/test.py
@@ -18,12 +18,12 @@ from nose.tools import eq_, assert_equal, raises
 
 @raises(sass.CompileError)
 def test1():
-	result = sass.compile_string('asd', '', sass.SASS_STYLE_NESTED)
-	eq_(result, 'asd')
+	result = sass.compile_string(b'asd', '', sass.SASS_STYLE_NESTED)
+	eq_(result, b'asd')
 
 
 def test2():
-	result = sass.compile_string('''table.hl {
+	result = sass.compile_string(b'''table.hl {
   margin: 2em 0;
   td.ln {
     text-align: right;
@@ -38,7 +38,7 @@ li {
   }
 }''', '', sass.SASS_STYLE_NESTED)
 
-	expected = '''table.hl {
+	expected = b'''table.hl {
   margin: 2em 0; }
   table.hl td.ln {
     text-align: right; }


### PR DESCRIPTION
Previously, if no `include_paths` were specified in Python 3, you would get an error about the code expecting bytes, but getting a str object instead.

Additionally, when running the tests on Python 3, the same thing would happen.

This commit fixes those issues so that it runs properly on 2 and 3. I ran the unit tests, plus some of my own code on both 2.7 and 3.3.
